### PR TITLE
feat: detect raw equation envs.

### DIFF
--- a/src/features/matrix_shortcuts.ts
+++ b/src/features/matrix_shortcuts.ts
@@ -17,20 +17,10 @@ export const runMatrixShortcuts = (
     const settings = getLatexSuiteConfig(view, latexSuiteConfig);
 
     // Check whether we are inside a matrix / align / case environment
-    let isInsideAnEnv = false;
-
-    for (const envName of settings.matrixShortcutsEnvNames) {
-        const env = {
-            openSymbol: "\\begin{" + envName + "}",
-            closeSymbol: "\\end{" + envName + "}",
-        };
-
-        isInsideAnEnv = ctx.isWithinEnvironment(ctx.pos, env, syntaxTree);
-        if (isInsideAnEnv) break;
+    const envName = ctx.getEnvironmentName(syntaxTree);
+    if (!envName || !settings.matrixShortcutsEnvNames.includes(envName)) {
+        return false;
     }
-
-    if (!isInsideAnEnv) return false;
-
     // Take main cursor since ctx.mode takes the main cursor, weird behaviour is expected with multicursor because of this.
     if (key === "Tab" && view.state.selection.main.empty) {
         view.dispatch(view.state.replaceSelection(" & "));

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -133,7 +133,7 @@ export const handleKeydown = (
         }
     }
 
-    if (key === "Tab" || key === "Enter") {
+    if (key === "Tab") {
         success = setSelectionToNextTabstop(view, tabstopsStateField);
 
         if (success) return true;

--- a/src/snippets/options.ts
+++ b/src/snippets/options.ts
@@ -45,6 +45,8 @@ export class Mode {
     parenInlineMath: boolean;
     bracketBlockMath: boolean;
     textEnv: boolean;
+    equation: boolean;
+    array: boolean;
 
     /** Whether the state is inside an inline math environment. */
     get inlineMath(): boolean {
@@ -53,13 +55,12 @@ export class Mode {
 
     /** Whether the state is inside a block math environment. */
     get blockMath(): boolean {
-        return this.dollarBlockMath || this.bracketBlockMath;
-    }
-    /**
-     * Whether the state is inside an equation bounded by $ or $$ delimeters.
-     */
-    inEquation(): boolean {
-        return this.inlineMath || this.blockMath;
+        return (
+            this.dollarBlockMath ||
+            this.bracketBlockMath ||
+            this.equation ||
+            this.array
+        );
     }
 
     /**
@@ -87,6 +88,8 @@ export class Mode {
         this.dollarInlineMath = false;
         this.dollarBlockMath = false;
         this.parenInlineMath = false;
+        this.equation = false;
+        this.array = false;
     }
 
     invert() {
@@ -108,6 +111,8 @@ export class Mode {
                     mode.dollarBlockMath = true;
                     mode.parenInlineMath = true;
                     mode.dollarInlineMath = true;
+                    mode.equation = true;
+                    mode.array = true;
                     break;
                 case "n":
                     mode.dollarInlineMath = true;
@@ -116,6 +121,8 @@ export class Mode {
                 case "M":
                     mode.bracketBlockMath = true;
                     mode.dollarBlockMath = true;
+                    mode.equation = true;
+                    mode.array = true;
                     break;
                 case "t":
                     mode.text = true;


### PR DESCRIPTION
Detect when the cursors is inside a equation block: `\begin{equation}...\end{equation}` or inside an equationArray block: `\begin{align}...\end{align}` and find the bounds through the syntax tree instead of parsing it ourselves.
