### PR TITLE
[FEATURE] color and highlight brackets inside math environments

### DIFF
--- a/browser_extension/settings/settings_tab.ts
+++ b/browser_extension/settings/settings_tab.ts
@@ -278,6 +278,7 @@ class LatexSuiteSettingTab {
     display() {
         this.displaySnippetSettings();
         this.displayConcealSettings();
+        this.displayColorHighlightBracketsSettings();
         this.displayAutofractionSettings();
         this.displayMatrixShortcutsSettings();
         this.displayTaboutSettings();
@@ -408,6 +409,60 @@ class LatexSuiteSettingTab {
                             this.plugin.saveSettings();
                         }
                     }),
+            );
+    }
+
+    displayColorHighlightBracketsSettings() {
+        const containerEl = this.containerEl;
+        this.addHeading(
+            containerEl,
+            "Highlight and color brackets",
+            "parentheses",
+        );
+
+        new Setting(containerEl)
+            .setName("Color paired brackets")
+            .setDesc("Whether to colorize matching brackets.")
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(this.plugin.settings.colorPairedBracketsEnabled)
+                    .onChange(async (value) => {
+                        this.plugin.settings.colorPairedBracketsEnabled = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+        new Setting(containerEl)
+            .setName("Highlight matching bracket beneath cursor")
+            .setDesc(
+                "When the cursor is adjacent to a bracket, highlight the matching bracket.",
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(
+                        this.plugin.settings.highlightCursorBracketsEnabled,
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.highlightCursorBracketsEnabled =
+                            value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName("Highlighting theme")
+            .setDesc(
+                "Whether to use a dark or light theme to highlight/color the brackets.",
+            )
+            .addDropdown((dropdown) =>
+                dropdown
+                    .setValue(this.plugin.settings.theme)
+                    .onChange(async (value) => {
+                        this.plugin.settings.theme =
+                            value as LatexSuitePluginSettingsRaw["theme"];
+                        await this.plugin.saveSettings();
+                    })
+                    .addOption("light", "Light")
+                    .addOption("dark", "Dark"),
             );
     }
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -98,6 +98,7 @@ const inlin_plugin = (options) => {
     };
 };
 
+/**@type {Partial<import('esbuild').BuildOptions>} */
 const sharedConfig = {
     banner: {
         js: banner,
@@ -111,6 +112,7 @@ const sharedConfig = {
     logLevel: "info",
 };
 
+/**@type {Partial<import('esbuild').BuildOptions>} */
 const browserConfig = {
     ...sharedConfig,
     entryPoints: [
@@ -122,6 +124,7 @@ const browserConfig = {
     outdir: "browser_extension/dist",
     external: ["path", "fs"],
     metafile: true,
+    mainFields: ["module", "browser", "main"],
 };
 
 const codemirrorConfig = {

--- a/src/conceal_plugin/conceal.ts
+++ b/src/conceal_plugin/conceal.ts
@@ -391,10 +391,15 @@ export const mkConcealPlugin = (
                         update.docChanged ||
                         update.viewportChanged ||
                         update.selectionSet
-                    ) ||
-                    !settings.concealEnabled
+                    )
                 )
                     return;
+                if (!settings.concealEnabled) {
+                    this.delayedReveal.cancel();
+                    this.decorations = Decoration.none;
+                    this.atomicRanges = RangeSet.empty;
+                    return;
+                }
                 revealTimeout = settings.concealRevealTimeout;
                 this.delayedReveal // Cancel the delayed revealment whenever we update the concealments
                     .cancel();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,10 @@ import { mkConcealPlugin } from "./conceal_plugin/conceal";
 import type { RawSnippet, SnippetVariables } from "./snippets/parse";
 import type { TabstopGroupC } from "./snippets/tabstop";
 import type { ProcessSnippetResult, SnippetData } from "./snippets/snippets";
+import {
+    colorPairedBracketsPluginLowestPrec,
+    highlightCursorBracketsPlugin,
+} from "./highlight_brackets_plugin/highlight_brackets";
 
 type CodeMirrorExt = {
     Decoration: typeof DecorationC;
@@ -176,6 +180,68 @@ export function main(
     ).extension;
 
     extensions.push(conceal_plugin);
+
+    const highlighting_brackets = [
+        colorPairedBracketsPluginLowestPrec(
+            Prec,
+            ViewPlugin,
+            Decoration,
+            syntaxTree,
+            latexSuiteConfig,
+        ),
+        highlightCursorBracketsPlugin(
+            ViewPlugin,
+            Decoration,
+            latexSuiteConfig,
+            syntaxTree,
+        ),
+    ];
+    extensions.push(...highlighting_brackets);
+    const dark_theme_extension = EditorView.theme(
+        {
+            '.latex-suite-color-bracket-0-dark, .latex-suite-color-bracket-0-dark [class^="tok-"], .latex-suite-color-bracket-0-dark .cm-bracket, .latex-suite-color-bracket-0-dark .cm-math':
+                {
+                    color: "#47b8ff",
+                },
+            '.latex-suite-color-bracket-1-dark, .latex-suite-color-bracket-1-dark [class^="tok-"], .latex-suite-color-bracket-1-dark .cm-bracket, .latex-suite-color-bracket-1-dark .cm-math':
+                {
+                    color: "#ff55cd",
+                },
+            '.latex-suite-color-bracket-2-dark, .latex-suite-color-bracket-2-dark [class^="tok-"], .latex-suite-color-bracket-2-dark .cm-bracket, .latex-suite-color-bracket-2-dark .cm-math':
+                {
+                    color: "#73ff63",
+                },
+            ".latex-suite-highlighted-bracket-dark, .latex-suite-highlighted-bracket-dark .cm-bracket, .latex-suite-highlighted-bracket-dark .cm-math ":
+                {
+                    backgroundColor: "hsla(170, 50%, 40%, 0.3)",
+                },
+        },
+        { dark: true },
+    );
+
+    const light_theme_extension = EditorView.theme(
+        {
+            '.latex-suite-color-bracket-0-light, .latex-suite-color-bracket-0-light [class^="tok-"], .latex-suite-color-bracket-0-light .cm-bracket, .latex-suite-color-bracket-0-light .cm-math':
+                {
+                    color: "#527aff",
+                },
+            '.latex-suite-color-bracket-1-light, .latex-suite-color-bracket-1-light [class^="tok-"], .latex-suite-color-bracket-1-light .cm-bracket, .latex-suite-color-bracket-1-light .cm-math':
+                {
+                    color: "#ff50b7",
+                },
+            '.latex-suite-color-bracket-2-light, .latex-suite-color-bracket-2-light [class^="tok-"], .latex-suite-color-bracket-2-light .cm-bracket, .latex-suite-color-bracket-2-light .cm-math':
+                {
+                    color: "#69ba00",
+                },
+            ".latex-suite-highlighted-bracket-light, .latex-suite-highlighted-bracket-light .cm-bracket, .latex-suite-highlighted-bracket-light .cm-math ":
+                {
+                    backgroundColor: "hsla(170, 50%, 70%, 0.6)",
+                },
+        },
+        { dark: false },
+    );
+    extensions.push(light_theme_extension, dark_theme_extension);
+
     return { latexSuiteConfig, extension: extensions };
 }
 

--- a/src/highlight_brackets_plugin/highlight_brackets.ts
+++ b/src/highlight_brackets_plugin/highlight_brackets.ts
@@ -1,0 +1,344 @@
+import type {
+    EditorView as EditorViewC,
+    ViewUpdate as ViewUpdateC,
+    Decoration as DecorationC,
+    DecorationSet as DecorationSetC,
+    ViewPlugin as ViewPluginC,
+} from "@codemirror/view";
+import type { Prec as PrecC, Range as RangeC } from "@codemirror/state";
+import {
+    findMatchingBracket,
+    getOpenBracket,
+    getCloseBracket,
+} from "../utils/editor_utils";
+import type { syntaxTree as syntaxTreeC } from "@codemirror/language";
+import { type Bounds, Context, getEquationBounds } from "src/utils/context";
+import {
+    getLatexSuiteConfig,
+    type LatexSuiteFacet,
+} from "src/settings/settings";
+
+const Ncolors = 3;
+
+function getHighlightBracketMark(
+    pos: number,
+    className: string,
+    Decoration: typeof DecorationC,
+): RangeC<DecorationC> {
+    return Decoration.mark({
+        inclusive: true,
+        attributes: {},
+        class: className,
+    }).range(pos, pos + 1);
+}
+
+function colorPairedBrackets(
+    view: EditorViewC,
+    syntaxTree: typeof syntaxTreeC,
+    Decoration: typeof DecorationC,
+    theme: "light" | "dark",
+): DecorationSetC {
+    const widgets: RangeC<DecorationC>[] = [];
+
+    for (const { from, to } of view.visibleRanges) {
+        const math_ranges: Bounds[] = [];
+        syntaxTree(view.state).iterate({
+            from,
+            to,
+            enter: (node) => {
+                if (node.name !== "Math") {
+                    return;
+                } else if (
+                    math_ranges.length === 0 ||
+                    node.to > math_ranges[math_ranges.length - 1].end
+                ) {
+                    math_ranges.push({ start: node.from, end: node.to });
+                }
+            },
+        });
+        for (const bounds of math_ranges) {
+            const eqn = view.state.doc.sliceString(bounds.start, bounds.end);
+
+            const openBrackets = ["{", "[", "("];
+            const closeBrackets = ["}", "]", ")"];
+
+            const bracketsStack = [];
+            const bracketsPosStack = [];
+
+            for (let i = 0; i < eqn.length; i++) {
+                const char = eqn.charAt(i);
+
+                if (openBrackets.includes(char)) {
+                    bracketsStack.push(char);
+                    bracketsPosStack.push(i);
+                } else if (closeBrackets.includes(char)) {
+                    const lastBracket = bracketsStack[bracketsStack.length - 1];
+                    if (getCloseBracket(lastBracket) === char) {
+                        bracketsStack.pop();
+                        const lastBracketPos = bracketsPosStack.pop();
+                        const depth = bracketsStack.length % Ncolors;
+
+                        const className =
+                            "latex-suite-color-bracket-" + depth + "-" + theme;
+
+                        const j = lastBracketPos + bounds.start;
+                        const k = i + bounds.start;
+
+                        widgets.push(
+                            getHighlightBracketMark(j, className, Decoration),
+                        );
+                        widgets.push(
+                            getHighlightBracketMark(k, className, Decoration),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    return Decoration.set(widgets, true);
+}
+
+function getEnclosingBracketsPos(
+    view: EditorViewC,
+    pos: number,
+    syntaxTree: typeof syntaxTreeC,
+): { left: number; right: number } | -1 {
+    const result = getEquationBounds(view.state, syntaxTree);
+    if (!result) return -1;
+    const { start, end } = result;
+    const text = view.state.doc.sliceString(start, end);
+
+    for (let i = pos - start; i > 0; i--) {
+        let curChar = text.charAt(i);
+
+        if ([")", "]", "}"].includes(curChar)) {
+            const closeBracket = curChar;
+            const openBracket = getOpenBracket(closeBracket);
+
+            const j = findMatchingBracket(
+                text,
+                i,
+                openBracket,
+                closeBracket,
+                true,
+            );
+
+            if (j === -1) return -1;
+
+            // Skip to the beginnning of the bracket
+            i = j;
+            curChar = text.charAt(i);
+        } else {
+            if (!["{", "(", "["].includes(curChar)) continue;
+
+            const j = findMatchingBracket(
+                text,
+                i,
+                curChar,
+                getCloseBracket(curChar),
+                false,
+            );
+            if (j === -1) continue;
+
+            return { left: i + start, right: j + start };
+        }
+    }
+
+    return -1;
+}
+
+function highlightCursorBrackets(
+    view: EditorViewC,
+    Decoration: typeof DecorationC,
+    latexSuiteConfig: LatexSuiteFacet,
+    syntaxTree: typeof syntaxTreeC,
+) {
+    const widgets: RangeC<DecorationC>[] = [];
+    const selection = view.state.selection;
+    const ranges = selection.ranges;
+    const text = view.state.doc.toString();
+    const ctx = Context.fromView(view, latexSuiteConfig, syntaxTree);
+
+    if (!ctx.mode.inMath()) {
+        return Decoration.none;
+    }
+
+    const bounds = ctx.getBounds(syntaxTree, selection.main.to);
+    if (!bounds) return Decoration.none;
+    const eqn = view.state.doc.sliceString(bounds.start, bounds.end);
+
+    const openBrackets = ["{", "[", "("];
+    const brackets = ["{", "[", "(", "}", "]", ")"];
+
+    let done = false;
+    const theme = getLatexSuiteConfig(view, latexSuiteConfig).theme;
+    const className = "latex-suite-highlighted-bracket-" + theme;
+    for (const range of ranges) {
+        for (let i = Math.max(0, range.from - 1); i <= range.to; i++) {
+            const char = text.charAt(i);
+            if (!brackets.includes(char)) continue;
+
+            let openBracket, closeBracket;
+            let backwards = false;
+
+            if (openBrackets.includes(char)) {
+                openBracket = char;
+                closeBracket = getCloseBracket(openBracket);
+            } else {
+                closeBracket = char;
+                openBracket = getOpenBracket(char);
+                backwards = true;
+            }
+
+            let j = findMatchingBracket(
+                eqn,
+                i - bounds.start,
+                openBracket,
+                closeBracket,
+                backwards,
+            );
+
+            if (j === -1) continue;
+            j = j + bounds.start;
+
+            widgets.push(getHighlightBracketMark(i, className, Decoration));
+            widgets.push(getHighlightBracketMark(j, className, Decoration));
+            done = true;
+            break;
+        }
+
+        if (done) break;
+
+        // Highlight brackets enclosing the cursor
+        if (range.empty) {
+            const pos = range.from - 1;
+
+            const result = getEnclosingBracketsPos(view, pos, syntaxTree);
+            if (result === -1) continue;
+
+            widgets.push(
+                getHighlightBracketMark(result.left, className, Decoration),
+            );
+            widgets.push(
+                getHighlightBracketMark(result.right, className, Decoration),
+            );
+            done = true;
+            break;
+        }
+
+        if (done) break;
+    }
+
+    return Decoration.set(widgets, true);
+}
+
+const colorPairedBracketsPlugin = (
+    ViewPlugin: typeof ViewPluginC,
+    Decoration: typeof DecorationC,
+    syntaxTree: typeof syntaxTreeC,
+    latexSuiteConfig: LatexSuiteFacet,
+) =>
+    ViewPlugin.fromClass(
+        class {
+            decorations: DecorationSetC;
+
+            constructor(view: EditorViewC) {
+                if (
+                    !getLatexSuiteConfig(view, latexSuiteConfig)
+                        .colorPairedBracketsEnabled
+                ) {
+                    this.decorations = Decoration.none;
+                    return;
+                }
+                this.decorations = colorPairedBrackets(
+                    view,
+                    syntaxTree,
+                    Decoration,
+                    getLatexSuiteConfig(view, latexSuiteConfig).theme,
+                );
+            }
+
+            update(update: ViewUpdateC) {
+                if (
+                    !getLatexSuiteConfig(update.view, latexSuiteConfig)
+                        .colorPairedBracketsEnabled
+                ) {
+                    this.decorations = Decoration.none;
+                    return;
+                }
+                if (update.docChanged || update.viewportChanged) {
+                    this.decorations = colorPairedBrackets(
+                        update.view,
+                        syntaxTree,
+                        Decoration,
+                        getLatexSuiteConfig(update.view, latexSuiteConfig)
+                            .theme,
+                    );
+                }
+            }
+        },
+        { decorations: (v) => v.decorations },
+    );
+
+export const colorPairedBracketsPluginLowestPrec = (
+    Prec: typeof PrecC,
+    ViewPlugin: typeof ViewPluginC,
+    Decoration: typeof DecorationC,
+    syntaxTree: typeof syntaxTreeC,
+    latexSuiteConfig: LatexSuiteFacet,
+) =>
+    Prec.lowest(
+        colorPairedBracketsPlugin(
+            ViewPlugin,
+            Decoration,
+            syntaxTree,
+            latexSuiteConfig,
+        ).extension,
+    );
+
+export const highlightCursorBracketsPlugin = (
+    ViewPlugin: typeof ViewPluginC,
+    Decoration: typeof DecorationC,
+    latexSuiteConfig: LatexSuiteFacet,
+    syntaxTree: typeof syntaxTreeC,
+) =>
+    ViewPlugin.fromClass(
+        class {
+            decorations: DecorationSetC;
+
+            constructor(view: EditorViewC) {
+                if (
+                    !getLatexSuiteConfig(view, latexSuiteConfig)
+                        .highlightCursorBracketsEnabled
+                ) {
+                    this.decorations = Decoration.none;
+                    return;
+                }
+                this.decorations = highlightCursorBrackets(
+                    view,
+                    Decoration,
+                    latexSuiteConfig,
+                    syntaxTree,
+                );
+            }
+
+            update(update: ViewUpdateC) {
+                if (
+                    !getLatexSuiteConfig(update.view, latexSuiteConfig)
+                        .highlightCursorBracketsEnabled
+                ) {
+                    this.decorations = Decoration.none;
+                    return;
+                }
+                if (update.docChanged || update.selectionSet)
+                    this.decorations = highlightCursorBrackets(
+                        update.view,
+                        Decoration,
+                        latexSuiteConfig,
+                        syntaxTree,
+                    );
+            }
+        },
+        { decorations: (v) => v.decorations },
+    );

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -7,7 +7,7 @@ import { tabout, shouldTaboutByCloseBracket } from "./features/tabout";
 import { runMatrixShortcuts } from "./features/matrix_shortcuts";
 
 import { Context } from "./utils/context";
-import { getCharacterAtPos, replaceRange } from "./utils/editor_utils";
+import { replaceRange } from "./utils/editor_utils";
 import {
     type expandSnippetsC,
     setSelectionToNextTabstop,

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -26,6 +26,8 @@ interface LatexSuiteBasicSettings {
     autoDelete$: boolean;
     concealEnabled: boolean;
     concealRevealTimeout: number;
+    colorPairedBracketsEnabled: boolean;
+    highlightCursorBracketsEnabled: boolean;
     autofractionEnabled: boolean;
     autofractionSymbol: string;
     autofractionBreakingChars: string;
@@ -33,6 +35,7 @@ interface LatexSuiteBasicSettings {
     taboutEnabled: boolean;
     autoEnlargeBrackets: boolean;
     wordDelimiters: string;
+    theme: "light" | "dark";
 }
 
 /**
@@ -79,6 +82,8 @@ export const DEFAULT_SETTINGS: LatexSuitePluginSettings &
     autoDelete$: true,
     concealEnabled: true,
     concealRevealTimeout: 0,
+    colorPairedBracketsEnabled: true,
+    highlightCursorBracketsEnabled: true,
     autofractionEnabled: true,
     autofractionSymbol: "\\frac",
     autofractionBreakingChars: "+-=\t",
@@ -86,6 +91,7 @@ export const DEFAULT_SETTINGS: LatexSuitePluginSettings &
     taboutEnabled: true,
     autoEnlargeBrackets: true,
     wordDelimiters: "., +-\\n\t:;!?\\/{}[]()=~$",
+    theme: "light",
 
     // Raw settings
     autofractionExcludedEnvs: '[\n\t["^{", "}"],\n\t["\\\\pu{", "}"]\n]',
@@ -362,5 +368,25 @@ export const SETTINGS_EXPLANATIONS: LatexSuitePluginSettingsExplanations = {
             " How long to delay the reveal of LaTeX for, in milliseconds, when the cursor moves over LaTeX. Defaults to 0 (LaTeX under the cursor is revealed immediately).\n Can be set to a positive number, e.g. 300, to delay the reveal of LaTeX, making it much easier to navigate equations using arrow keys.\n Must be an integer ≥ 0. ",
         type: "string",
         defaultValue: DEFAULT_SETTINGS.concealRevealTimeout,
+    },
+    colorPairedBracketsEnabled: {
+        title: "Color paired brackets",
+        description: "Whether to colorize matching brackets.",
+        type: "boolean",
+        defaultValue: DEFAULT_SETTINGS.colorPairedBracketsEnabled,
+    },
+    highlightCursorBracketsEnabled: {
+        title: "Highlight matching bracket beneath cursor",
+        description:
+            "When the cursor is adjacent to a bracket, highlight the matching bracket.",
+        type: "boolean",
+        defaultValue: DEFAULT_SETTINGS.highlightCursorBracketsEnabled,
+    },
+    theme: {
+        title: "Highlighting theme",
+        description:
+            "Whether to use a dark or light theme to highlight/color the brackets.",
+        type: ["light", "dark"],
+        defaultValue: DEFAULT_SETTINGS.theme,
     },
 } as const;

--- a/src/snippets/parse.ts
+++ b/src/snippets/parse.ts
@@ -24,8 +24,7 @@ import { sortSnippets } from "./sort";
 import type { Environment } from "./environment";
 import { EXCLUSIONS } from "./environment";
 import { convert_replacement_v1_to_v2 } from "src/convert_spec";
-import * as json5 from "json5";
-
+import json5 from "json5";
 export type SnippetVariables = Record<`$\{${string}}`, string>;
 
 export async function importRaw(maybeJavaScriptCode: string) {

--- a/src/utils/default_snippet_variables.ts
+++ b/src/utils/default_snippet_variables.ts
@@ -1,10 +1,10 @@
 // @ts-ignore
 import default_snippet_variables_str from "inline:src/default_snippet_variables.json5";
-import { parse } from "json5";
+import json5 from "json5";
 import type { SnippetVariables } from "src/extension";
 
 export const DEFAULT_SNIPPET_VARIABLES_str: string =
     default_snippet_variables_str;
-export const DEFAULT_SNIPPET_VARIABLES: SnippetVariables = parse(
+export const DEFAULT_SNIPPET_VARIABLES: SnippetVariables = json5.parse(
     default_snippet_variables_str,
 );

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,58 @@
+:root {
+    --acent-h: 170;
+    --accent-s: 50;
+}
+/* Highlight brackets */
+.theme-light .latex-suite-highlighted-bracket,
+.theme-light
+    .latex-suite-highlighted-bracket
+    [class^="latex-suite-color-bracket-"] {
+    background-color: hsl(var(--accent-h), var(--accent-s), 40%, 0.3);
+    background-color: black;
+}
+
+.theme-dark .latex-suite-highlighted-bracket,
+.theme-dark
+    .latex-suite-highlighted-bracket
+    [class^="latex-suite-color-bracket-"] {
+    background-color: hsl(var(--accent-h), var(--accent-s), 70%, 0.6);
+}
+/* .latex-suite-highlighted-bracket {
+    background-color: black;
+} */
+
+/* Color matching brackets */
+
+.theme-light .latex-suite-color-bracket-0,
+.theme-light .latex-suite-color-bracket-0 .cm-bracket {
+    color: #527aff;
+}
+
+.theme-light .latex-suite-color-bracket-1,
+.theme-light .latex-suite-color-bracket-1 .cm-bracket {
+    color: #ff50b7;
+}
+
+.theme-light .latex-suite-color-bracket-2,
+.theme-light .latex-suite-color-bracket-2 .cm-bracket {
+    color: #69ba00;
+}
+
+.theme-dark .latex-suite-color-bracket-0,
+.theme-dark .latex-suite-color-bracket-0 .cm-bracket {
+    color: #47b8ff;
+}
+
+.theme-dark .latex-suite-color-bracket-1,
+.theme-dark .latex-suite-color-bracket-1 .cm-bracket {
+    color: #ff55cd;
+}
+
+.theme-dark .latex-suite-color-bracket-2,
+.theme-dark .latex-suite-color-bracket-2 .cm-bracket {
+    color: #73ff63;
+}
+
+/* .latex-suite-color-bracket-3 {
+    color: #8de15c;
+} */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "target": "ES2017",
         "allowJs": true,
         "noImplicitAny": true,
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "importHelpers": true,
         "declaration": true,
 


### PR DESCRIPTION
when inside brackets it highlights the matching brackets even when not touching those.
matching brackets are colored with 3 different colors inside math to make it clearer which bracket matches with which like in code editors.

also made concealment and highlighting brackets live configurable and
used ts transpiler in the script that sends the settings to convert from
ts to js. This was done in there to since the typescript library is
large and it would slow down the parsing of the main module causing it
not to load.
