### PR TITLE
feat: add chromium support

### DIFF
--- a/browser_extension/manifest.json
+++ b/browser_extension/manifest.json
@@ -16,10 +16,6 @@
         }
     ],
     "permissions": ["storage"],
-    "options_ui": {
-        "page": "settings.html",
-        "open_in_tab": true
-    },
     "web_accessible_resources": [
         {
             "resources": [
@@ -29,6 +25,7 @@
             "matches": ["<all_urls>"]
         }
     ],
+    "options_page": "settings.html",
     "action": {
         "default_popup": "popup.html"
     },

--- a/browser_extension/package.json
+++ b/browser_extension/package.json
@@ -10,7 +10,11 @@
         "@valtown/codemirror-ts": "^2.2.1",
         "codemirror": "^6.0.2",
         "lz-string": "^1.5.0",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.2",
+        "webextension-polyfill": "^0.12.0"
     },
-    "devDependencies": {}
+    "devDependencies": {
+        "@types/webextension-polyfill": "^0.12.3",
+        "web-ext-option-types": "^8.9.5"
+    }
 }

--- a/browser_extension/popup.js
+++ b/browser_extension/popup.js
@@ -1,1 +1,8 @@
-(browser ?? chrome).tabs.create({ url: "settings.html" });
+(window.browser ?? window.chrome).tabs.create({ url: "settings.html" });
+setTimeout(() => {
+    try {
+        window.close();
+    } catch (e) {
+        console.error("Error closing window:", e);
+    }
+}, 100);

--- a/browser_extension/settings/content_script.ts
+++ b/browser_extension/settings/content_script.ts
@@ -1,8 +1,9 @@
-/// <reference types="firefox-webext-browser" />
+// /// <reference types="firefox-webext-browser" />
 
 import { compressToUint8Array, decompressFromUint8Array } from "lz-string";
 import { DEFAULT_SETTINGS_RAW } from "../../src/settings/settings";
 import * as ts from "typescript";
+import browser from "webextension-polyfill";
 
 async function send_config(): Promise<void> {
     const config = await get_transpiled_settings();

--- a/browser_extension/settings/settings_tab.ts
+++ b/browser_extension/settings/settings_tab.ts
@@ -1,4 +1,3 @@
-import { compressToUint8Array, decompressFromUint8Array } from "lz-string";
 import type { LatexSuitePluginSettingsRaw } from "../../src/settings/settings";
 import { DEFAULT_SETTINGS_RAW } from "../../src/settings/settings";
 import { EditorView } from "@codemirror/view";

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,13 +58,27 @@
             }
         },
         "browser_extension": {
+            "name": "snippetleaf",
             "version": "0.0.1",
             "dependencies": {
                 "@typescript/vfs": "^1.6.1",
                 "@valtown/codemirror-ts": "^2.2.1",
                 "codemirror": "^6.0.2",
                 "lz-string": "^1.5.0",
-                "typescript": "^5.9.2"
+                "typescript": "^5.9.2",
+                "webextension-polyfill": "^0.12.0"
+            },
+            "devDependencies": {
+                "@types/webextension-polyfill": "^0.12.3",
+                "web-ext-option-types": "^8.9.5"
+            }
+        },
+        "codemirror_extension": {
+            "name": "codemirror-latex-suite",
+            "version": "0.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "codemirror": "^6.0.2"
             },
             "devDependencies": {}
         },
@@ -1748,6 +1762,12 @@
             "integrity": "sha512-wxGFP3aj57jvnCZPsKEt1cZF83ohN95A/tJME6oa2mjPlMmVZONos5LmRWJuaYtVw1WjDW36hMBYosMUGEo9Xw==",
             "dev": true
         },
+        "node_modules/@types/webextension-polyfill": {
+            "version": "0.12.3",
+            "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.12.3.tgz",
+            "integrity": "sha512-F58aDVSeN/MjUGazXo/cPsmR76EvqQhQ1v4x23hFjUX0cfAJYE+JBWwiOGW36/VJGGxoH74sVlRIF3z7SJCKyg==",
+            "dev": true
+        },
         "node_modules/@types/yauzl": {
             "version": "2.10.3",
             "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -3384,6 +3404,10 @@
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.0.0"
             }
+        },
+        "node_modules/codemirror-latex-suite": {
+            "resolved": "codemirror_extension",
+            "link": true
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -8741,6 +8765,12 @@
                 "npm": ">=8.0.0"
             }
         },
+        "node_modules/web-ext-option-types": {
+            "version": "8.9.5",
+            "resolved": "https://registry.npmjs.org/web-ext-option-types/-/web-ext-option-types-8.9.5.tgz",
+            "integrity": "sha512-1bxBLwbgjxWWEfmbF1DQsu4ncMsDF918spP3DkfkbKsU62JUywWMS8OgmyApgsWY1MVem0Y4xtM115enRIuUmw==",
+            "dev": true
+        },
         "node_modules/web-ext/node_modules/strip-bom": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-5.0.0.tgz",
@@ -8766,6 +8796,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/webextension-polyfill": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
+            "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q=="
         },
         "node_modules/when": {
             "version": "3.7.7",


### PR DESCRIPTION
use the webextension-polyfill package to target both browser and chrome object when using the browser object.