### PR TITLE
Feat/optimize snippets

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,6 @@ import {
 import { expandSnippets } from "./snippets/snippet_management";
 import { stateEffect_variables } from "./snippets/codemirror/history";
 import { create_tabstopsStateField } from "./snippets/codemirror/tabstops_state_field";
-import { snippetQueues } from "./snippets/codemirror/snippet_queue_state_field";
 import { mkConcealPlugin } from "./conceal_plugin/conceal";
 
 import type { RawSnippet, SnippetVariables } from "./snippets/parse";
@@ -123,8 +122,6 @@ export function main(
         Decoration,
         EditorView,
     );
-    const { clearSnippetQueue, queueSnippet, snippetQueueStateField } =
-        snippetQueues(StateEffect, StateField);
     const extensions: ExtensionC[] = [];
 
     const latexSuiteConfig: LatexSuiteFacet = Facet.define<
@@ -152,15 +149,11 @@ export function main(
                         syntaxTree,
                         removeAllTabstops,
                         tabstopsStateField,
-                        clearSnippetQueue,
-                        queueSnippet,
                         (view: EditorViewC) =>
                             expandSnippets(
                                 view,
                                 ChangeSet,
                                 isolateHistory,
-                                snippetQueueStateField,
-                                clearSnippetQueue,
                                 addTabstops,
                                 getTabstopGroupsFromView,
                                 getNextTabstopColor,
@@ -176,11 +169,7 @@ export function main(
         EditorView.updateListener.of((update: ViewUpdateC) =>
             handleUpdate(update, latexSuiteConfig, handleUndoRedo),
         ),
-        create_snippet_extensions(
-            tabstopsStateField,
-            snippetQueueStateField,
-            snippetInvertedEffects,
-        ),
+        create_snippet_extensions(tabstopsStateField, snippetInvertedEffects),
         latexSuiteConfig.of(CMSettings),
     ];
     extensions.push(...snippet_leaf_extension);

--- a/src/features/auto_enlarge_brackets.ts
+++ b/src/features/auto_enlarge_brackets.ts
@@ -1,16 +1,15 @@
 import type { EditorView as EditorViewC } from "@codemirror/view";
 import { findMatchingBracket } from "src/utils/editor_utils";
-import type { snippetQueues } from "src/snippets/codemirror/snippet_queue_state_field";
 import { Context } from "src/utils/context";
 import type { LatexSuiteFacet } from "src/settings/settings";
 import { getLatexSuiteConfig } from "src/settings/settings";
 import type { syntaxTree as syntaxTreeC } from "@codemirror/language";
+import { queueSnippet } from "src/snippets/codemirror/snippet_queue_state_field";
 
 export const autoEnlargeBrackets = (
     view: EditorViewC,
     latexSuiteConfig: LatexSuiteFacet,
     syntaxTree: typeof syntaxTreeC,
-    queueSnippet: ReturnType<typeof snippetQueues>["queueSnippet"],
     expandSnippets: (view: EditorViewC) => boolean,
 ) => {
     const settings = getLatexSuiteConfig(view, latexSuiteConfig);
@@ -76,18 +75,8 @@ export const autoEnlargeBrackets = (
         }
 
         // Enlarge the brackets
-        queueSnippet(
-            view,
-            start + i,
-            start + i + bracketSize,
-            left + open + " ",
-        );
-        queueSnippet(
-            view,
-            start + j,
-            start + j + bracketSize,
-            " " + right + close,
-        );
+        queueSnippet(start + i, start + i + bracketSize, left + open + " ");
+        queueSnippet(start + j, start + j + bracketSize, " " + right + close);
     }
 
     expandSnippets(view);

--- a/src/features/autofraction.ts
+++ b/src/features/autofraction.ts
@@ -1,43 +1,29 @@
 import type { EditorView } from "@codemirror/view";
 import type { SelectionRange } from "@codemirror/state";
 import { findMatchingBracket, getOpenBracket } from "src/utils/editor_utils";
-import type { snippetQueues } from "src/snippets/codemirror/snippet_queue_state_field";
 import type { expandSnippetsC } from "../snippets/snippet_management";
 import { autoEnlargeBrackets } from "./auto_enlarge_brackets";
 import type { Context } from "../utils/context";
 import type { LatexSuiteFacet } from "src/settings/settings";
 import { getLatexSuiteConfig } from "src/settings/settings";
 import type { syntaxTree as syntaxTreeC } from "@codemirror/language";
+import { queueSnippet } from "src/snippets/codemirror/snippet_queue_state_field";
 
 export const runAutoFraction = (
     view: EditorView,
     ctx: Context,
     latexSuiteConfig: LatexSuiteFacet,
     syntaxTree: typeof syntaxTreeC,
-    queueSnippet: ReturnType<typeof snippetQueues>["queueSnippet"],
     expandSnippets: expandSnippetsC,
 ): boolean => {
     for (const range of ctx.ranges) {
-        runAutoFractionCursor(
-            view,
-            ctx,
-            range,
-            latexSuiteConfig,
-            syntaxTree,
-            queueSnippet,
-        );
+        runAutoFractionCursor(view, ctx, range, latexSuiteConfig, syntaxTree);
     }
 
     const success = expandSnippets(view);
 
     if (success) {
-        autoEnlargeBrackets(
-            view,
-            latexSuiteConfig,
-            syntaxTree,
-            queueSnippet,
-            expandSnippets,
-        );
+        autoEnlargeBrackets(view, latexSuiteConfig, syntaxTree, expandSnippets);
     }
 
     return success;
@@ -49,7 +35,6 @@ export const runAutoFractionCursor = (
     range: SelectionRange,
     latexSuiteConfig: LatexSuiteFacet,
     syntaxTree: typeof syntaxTreeC,
-    queueSnippet: ReturnType<typeof snippetQueues>["queueSnippet"],
 ): boolean => {
     const settings = getLatexSuiteConfig(view, latexSuiteConfig);
     const { from, to } = range;
@@ -147,7 +132,7 @@ export const runAutoFractionCursor = (
         "@@",
     )}}{@0}@1`;
 
-    queueSnippet(view, start, to, replacement, "/");
+    queueSnippet(start, to, replacement, "/");
 
     return true;
 };

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -15,11 +15,11 @@ import {
 import type { create_tabstopsStateField } from "./snippets/codemirror/tabstops_state_field";
 import type { LatexSuiteFacet } from "./settings/settings";
 import { getLatexSuiteConfig } from "./settings/settings";
-import type { snippetQueues } from "./snippets/codemirror/snippet_queue_state_field";
 import type { stateEffect_variables } from "./snippets/codemirror/history";
 
 // import { handleMathTooltip } from "./editor_extensions/math_tooltip";
 import { isComposing } from "./utils/editor_utils";
+import { clearSnippetQueue } from "./snippets/codemirror/snippet_queue_state_field";
 
 export const handleUpdate = (
     update: ViewUpdate,
@@ -48,8 +48,6 @@ export const onKeydown = (
     tabstopsStateField: ReturnType<
         typeof create_tabstopsStateField
     >["tabstopsStateField"],
-    clearSnippetQueue: ReturnType<typeof snippetQueues>["clearSnippetQueue"],
-    queueSnippet: ReturnType<typeof snippetQueues>["queueSnippet"],
     expandSnippets: expandSnippetsC,
 ): boolean | void => {
     const success = handleKeydown(
@@ -62,8 +60,6 @@ export const onKeydown = (
         syntaxTree,
         removeAllTabstops,
         tabstopsStateField,
-        clearSnippetQueue,
-        queueSnippet,
         expandSnippets,
     );
 
@@ -84,8 +80,6 @@ export const handleKeydown = (
     tabstopsStateField: ReturnType<
         typeof create_tabstopsStateField
     >["tabstopsStateField"],
-    clearSnippetQueue: ReturnType<typeof snippetQueues>["clearSnippetQueue"],
-    queueSnippet: ReturnType<typeof snippetQueues>["queueSnippet"],
     expandSnippets: expandSnippetsC,
 ) => {
     const settings = getLatexSuiteConfig(view, latexSuiteConfig);
@@ -135,13 +129,12 @@ export const handleKeydown = (
                     ctx,
                     key,
                     latexSuiteConfig,
-                    queueSnippet,
                     expandSnippets,
                     syntaxTree,
                 );
                 if (success) return true;
             } catch (e) {
-                clearSnippetQueue(view);
+                clearSnippetQueue();
                 console.error(e);
             }
         }
@@ -160,7 +153,6 @@ export const handleKeydown = (
                 ctx,
                 latexSuiteConfig,
                 syntaxTree,
-                queueSnippet,
                 expandSnippets,
             );
 

--- a/src/snippets/codemirror/extensions.ts
+++ b/src/snippets/codemirror/extensions.ts
@@ -1,21 +1,13 @@
 import type { stateEffect_variables } from "./history";
 import type { create_tabstopsStateField } from "./tabstops_state_field";
-import type { snippetQueues } from "./snippet_queue_state_field";
 
 export function create_snippet_extensions(
     tabstopsStateField: ReturnType<
         typeof create_tabstopsStateField
     >["tabstopsStateField"],
-    snippetQueueStateField: ReturnType<
-        typeof snippetQueues
-    >["snippetQueueStateField"],
     snippetInvertedEffects: ReturnType<
         typeof stateEffect_variables
     >["snippetInvertedEffects"],
 ) {
-    return [
-        tabstopsStateField.extension,
-        snippetQueueStateField.extension,
-        snippetInvertedEffects,
-    ];
+    return [tabstopsStateField.extension, snippetInvertedEffects];
 }

--- a/src/snippets/codemirror/snippet_change_spec.ts
+++ b/src/snippets/codemirror/snippet_change_spec.ts
@@ -1,5 +1,4 @@
-import type { EditorView } from "@codemirror/view";
-import type { ChangeSpec } from "@codemirror/state";
+import type { ChangeSpec, Text } from "@codemirror/state";
 import type { TabstopSpec } from "../tabstop";
 
 /**
@@ -53,11 +52,8 @@ export class SnippetChangeSpec {
             }).filter((val) => val !== undefined) || [];
     }
 
-    getTabstops(view: EditorView, start: number): TabstopSpec[] {
-        const text = view.state.doc.sliceString(
-            start,
-            start + this.insert.length,
-        );
+    getTabstops(doc: Text, start: number): TabstopSpec[] {
+        const text = doc.sliceString(start, start + this.insert.length);
 
         const matches = text.matchAll(tabstop_regex);
         const tabstops: TabstopSpec[] = Array.from(

--- a/src/snippets/codemirror/snippet_queue_state_field.ts
+++ b/src/snippets/codemirror/snippet_queue_state_field.ts
@@ -1,59 +1,33 @@
-import type { EditorView } from "@codemirror/view";
-import type {
-    StateEffect as StateEffectC,
-    StateField as StateFieldC,
-} from "@codemirror/state";
 import { SnippetChangeSpec } from "./snippet_change_spec";
+class SnippetQueue {
+    private snippetQueue: SnippetChangeSpec[] = [];
 
-export function snippetQueues(
-    StateEffect: typeof StateEffectC,
-    StateField: typeof StateFieldC,
+    clearSnippetQueue() {
+        this.snippetQueue = [];
+    }
+
+    QueueSnippets(values: SnippetChangeSpec[]) {
+        this.snippetQueue = this.snippetQueue.concat(values);
+    }
+
+    get snippetQueueValue(): SnippetChangeSpec[] {
+        return this.snippetQueue.map(
+            (s) => new SnippetChangeSpec(s.from, s.to, s.insert, s.keyPressed),
+        );
+    }
+}
+export const snippetQueueStateField = new SnippetQueue();
+
+export function queueSnippet(
+    from: number,
+    to: number,
+    insert: string,
+    keyPressed?: string,
 ) {
-    const queueSnippetEffect = StateEffect.define<SnippetChangeSpec>();
-    const clearSnippetQueueEffect = StateEffect.define();
+    const snippet = new SnippetChangeSpec(from, to, insert, keyPressed);
+    snippetQueueStateField.QueueSnippets([snippet]);
+}
 
-    const snippetQueueStateField = StateField.define<SnippetChangeSpec[]>({
-        create() {
-            return [];
-        },
-
-        update(oldState, transaction) {
-            let snippetQueue = oldState;
-
-            for (const effect of transaction.effects) {
-                if (effect.is(queueSnippetEffect)) {
-                    snippetQueue.push(effect.value);
-                } else if (effect.is(clearSnippetQueueEffect)) {
-                    snippetQueue = [];
-                }
-            }
-
-            return snippetQueue;
-        },
-    });
-
-    function queueSnippet(
-        view: EditorView,
-        from: number,
-        to: number,
-        insert: string,
-        keyPressed?: string,
-    ) {
-        const snippet = new SnippetChangeSpec(from, to, insert, keyPressed);
-
-        view.dispatch({
-            effects: [queueSnippetEffect.of(snippet)],
-        });
-    }
-
-    function clearSnippetQueue(view: EditorView) {
-        view.dispatch({
-            effects: [clearSnippetQueueEffect.of(null)],
-        });
-    }
-    return {
-        queueSnippet,
-        clearSnippetQueue,
-        snippetQueueStateField,
-    };
+export function clearSnippetQueue() {
+    snippetQueueStateField.clearSnippetQueue();
 }

--- a/src/snippets/codemirror/tabstops_state_field.ts
+++ b/src/snippets/codemirror/tabstops_state_field.ts
@@ -25,7 +25,6 @@ export function create_tabstopsStateField(
 
         update(value, transaction) {
             let tabstopGroups = value;
-            tabstopGroups.forEach((grp) => grp.map(transaction.changes));
 
             for (const effect of transaction.effects) {
                 if (effect.is(addTabstopsEffect)) {
@@ -34,6 +33,7 @@ export function create_tabstopsStateField(
                     tabstopGroups = [];
                 }
             }
+            tabstopGroups.forEach((grp) => grp.map(transaction.changes));
 
             // Remove the tabstop groups that the cursor has passed. This scenario
             // happens when the user manually moves the cursor using arrow keys or mouse
@@ -88,10 +88,10 @@ export function create_tabstopsStateField(
         return currentTabstopGroups;
     }
 
-    function addTabstops(view: EditorViewC, tabstopGroups: TabstopGroupC[]) {
-        view.dispatch({
+    function addTabstops(tabstopGroups: TabstopGroupC[]) {
+        return {
             effects: [addTabstopsEffect.of(tabstopGroups)],
-        });
+        };
     }
 
     function removeAllTabstops(view: EditorViewC) {

--- a/src/snippets/codemirror/tabstops_state_field.ts
+++ b/src/snippets/codemirror/tabstops_state_field.ts
@@ -25,7 +25,9 @@ export function create_tabstopsStateField(
 
         update(value, transaction) {
             let tabstopGroups = value;
-
+            // Optimization: tabstops that are added should already have their changes applied
+            // So changes are only applied to existing tabstops
+            tabstopGroups.forEach((grp) => grp.map(transaction.changes));
             for (const effect of transaction.effects) {
                 if (effect.is(addTabstopsEffect)) {
                     tabstopGroups.unshift(...effect.value);
@@ -33,7 +35,6 @@ export function create_tabstopsStateField(
                     tabstopGroups = [];
                 }
             }
-            tabstopGroups.forEach((grp) => grp.map(transaction.changes));
 
             // Remove the tabstop groups that the cursor has passed. This scenario
             // happens when the user manually moves the cursor using arrow keys or mouse

--- a/src/snippets/snippet_management.ts
+++ b/src/snippets/snippet_management.ts
@@ -9,19 +9,18 @@ import type { isolateHistory as isolateHistoryC } from "@codemirror/commands";
 import type { TabstopSpec } from "./tabstop";
 import { tabstopSpecsToTabstopGroups } from "./tabstop";
 import type { create_tabstopsStateField } from "./codemirror/tabstops_state_field";
-import type { snippetQueues } from "./codemirror/snippet_queue_state_field";
 import type { SnippetChangeSpec } from "./codemirror/snippet_change_spec";
 import { resetCursorBlink } from "../utils/editor_utils";
+import {
+    clearSnippetQueue,
+    snippetQueueStateField,
+} from "./codemirror/snippet_queue_state_field";
 
 export type expandSnippetsC = (view: EditorView) => boolean;
 export function expandSnippets(
     view: EditorView,
     ChangeSet: typeof ChangeSetC,
     isolateHistory: typeof isolateHistoryC,
-    snippetQueueStateField: ReturnType<
-        typeof snippetQueues
-    >["snippetQueueStateField"],
-    clearSnippetQueue: ReturnType<typeof snippetQueues>["clearSnippetQueue"],
     addTabstops: ReturnType<typeof create_tabstopsStateField>["addTabstops"],
     getTabstopGroupsFromView: ReturnType<
         typeof create_tabstopsStateField
@@ -34,7 +33,7 @@ export function expandSnippets(
     EditorSelection: typeof EditorSelectionC,
     Decoration: typeof DecorationC,
 ): boolean {
-    const snippetsToExpand = view.state.field(snippetQueueStateField);
+    const snippetsToExpand = snippetQueueStateField.snippetQueueValue;
     if (snippetsToExpand.length === 0) return false;
 
     const originalDocLength = view.state.doc.length;
@@ -56,7 +55,7 @@ export function expandSnippets(
 
     // Insert any tabstops
     if (tabstopsToAdd.length === 0) {
-        clearSnippetQueue(view);
+        clearSnippetQueue();
         return true;
     }
 
@@ -71,7 +70,7 @@ export function expandSnippets(
     );
     expandTabstops(view, tabstopsToAdd, getTabstopGroupsFromView);
 
-    clearSnippetQueue(view);
+    clearSnippetQueue();
     return true;
 }
 


### PR DESCRIPTION
copy of https://github.com/artisticat1/obsidian-latex-suite/pull/450.


optimize snippet expansion and runSnippetCursor.

It doesn't differ that much from 0.5-0.7ms to 0.2-0.3ms, but running regex first and then excluded environments is faster in math.

The ShouldRunInSnippetMode is better if its first for text and worse for math, probably because there are more math snippets but it doesn't differ that much that it should be changed.

For expansion:

view.dispatch is very slow for large documents so adding to the queue, adding tabstops, replacing the snippet syntax and inserting the replacement is all done in one call now.

Its still 2 calls for automatic snippets and it could be maybe be done in one call by changing the code that handles when a snippet is undone and redone, but I don't currently have an idea how I would implement that.
