### PR TITLE
fix: No undefined for regex snippet

### DIFF
--- a/src/snippets/snippets.ts
+++ b/src/snippets/snippets.ts
@@ -197,7 +197,7 @@ export class RegexSnippet extends Snippet<"regex"> {
                           .join("|")})\\])`,
                       "g",
                   )
-                : new RegExp("");
+                : new RegExp("(?!)");
         const named_capture_groups = test_result.groups
             ? Object.keys(test_result.groups)
             : [];
@@ -209,7 +209,7 @@ export class RegexSnippet extends Snippet<"regex"> {
                   `@(?:@|\\[(${escapedNamedCaptureGroups.join("|")})\\])`,
                   "g",
               )
-            : new RegExp("");
+            : new RegExp("(?!)");
     }
 
     process(


### PR DESCRIPTION
Fixes #20.
When snippets were defined for version 1, something was captured and the replacement was a string, undefined would be placed before the string. Fixed by making the regex for detecting named groups not match anything instead of the empty string.